### PR TITLE
Add duration for Chrome University item in media feed example

### DIFF
--- a/media-feeds/media-feed.json
+++ b/media-feeds/media-feed.json
@@ -181,6 +181,7 @@
             "episode": {
               "@type": "TVEpisode",
               "@id": "https://www.youtube.com/watch?v=kNzoswFIU9M",
+              "duration": "PT15M33S",
               "episodeNumber": 10,
               "potentialAction": {
                 "@type": "WatchAction",
@@ -203,6 +204,7 @@
             "episode": {
               "@type": "TVEpisode",
               "@id": "https://www.youtube.com/watch?v=PzzNuCk-e0Y",
+              "duration": "PT10M15S",
               "episodeNumber": 1,
               "potentialAction": {
                 "@type": "WatchAction",


### PR DESCRIPTION
The episodes are missing a duration, but it is required by the spec.